### PR TITLE
Disable updating minor versions of Docker images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,10 @@
 {
   "extends": ["config:base"],
+  "docker": {
+    "minor": {
+      "enabled": false
+    }
+  },
   "docker-compose": {
     "digest": {
       "enabled": false


### PR DESCRIPTION
Specifically, Ubuntu 18.04 -> 18.10 is not a minor upgrade, and not one we want to take.