### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,9 @@ FROM ubuntu:18.04@sha256:0925d086715714114c1988f7c947db94064fd385e171a63c07730f1
 LABEL maintainer="Michael Cooper <mcooper@mozilla.com>"
 
 RUN apt-get update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends install -y \
         apt-transport-https \
+        apt-utils \
         bash \
         ca-certificates \
         curl \
@@ -17,7 +18,7 @@ RUN apt-get update \
     && apt-key fingerprint 0EBFCD88 \
     && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
     && apt-get update \
-    && apt-get install -y docker-ce=18.03.1~ce~3-0~ubuntu \
+    && apt-get --no-install-recommends install -y docker-ce=18.03.1~ce~3-0~ubuntu \
     && curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose \
     && chmod +x /usr/local/bin/docker-compose \
     && apt-get clean

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -3,8 +3,9 @@ FROM ubuntu:18.04@sha256:0925d086715714114c1988f7c947db94064fd385e171a63c07730f1
 LABEL maintainer="Michael Cooper <mcooper@mozilla.com>"
 
 RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
         apt-transport-https \
+        apt-utils \
         ca-certificates \
         curl \
         git \
@@ -14,17 +15,17 @@ RUN apt-get install -y \
         software-properties-common
 
 # Install Firefox dependencies (but not Firefox)
-RUN apt-get install -y $(apt-cache depends firefox | awk '/Depends/ {print $2}')
+RUN apt-get --no-install-recommends install -y $(apt-cache depends firefox | awk '/Depends/ {print $2}')
 
 # Install node
-RUN apt-get install -y nodejs npm
-RUN apt-get install apt-transport-https
+RUN apt-get --no-install-recommends install -y nodejs npm
+RUN apt-get --no-install-recommends install apt-transport-https
 
 # Install Yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
-    && apt-get install yarn
+    && apt-get --no-install-recommends install yarn
 ENV PATH="$PATH:$HOME/.yarn/bin"
 
 # Install Firefox

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Michael Cooper <mcooper@mozilla.com>"
 # kcov directly.
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y cmake g++ pkg-config jq libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev
+    apt-get --no-install-recommends install -y apt-utils ca-certificates cmake g++ pkg-config jq libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev
 RUN cargo install cargo-kcov
 RUN mkdir -p /tmp/kcov && \
     cd /tmp/kcov && \

--- a/therapist/Dockerfile
+++ b/therapist/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3-stretch@sha256:2f1eb47fe9222f760ae00b890b6033e5eff899789471337727f
 LABEL maintainer="Rehan Dalal <rdalal@mozilla.com>"
 
 RUN apt-get update
-RUN apt-get install -y apt-transport-https git
+RUN apt-get --no-install-recommends install -y apt-transport-https git apt-utils ca-certificates
 
 # Install node prereqs, nodejs and yarn
 # Ref: https://deb.nodesource.com/setup_10.x
@@ -14,7 +14,7 @@ RUN echo "deb https://deb.nodesource.com/node_10.x stretch main" > /etc/apt/sour
     echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
     wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     apt-get update && \
-    apt-get install -yqq nodejs yarn && \
+    apt-get --no-install-recommends install -yqq nodejs yarn && \
     npm i -g npm@>=6 && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is 

1.  Slow and in log it is showing because "apt-utils" not installed 

2. to avoid build to exits with error without having certificate