### PR TITLE
Install a modern version of Node in the Firefox image

### DIFF
--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -2,8 +2,10 @@ FROM ubuntu:18.04@sha256:e5dd9dbb37df5b731a6688fa49f4003359f6f126958c9c928f937be
 
 LABEL maintainer="Michael Cooper <mcooper@mozilla.com>"
 
-RUN apt-get update
-RUN apt-get --no-install-recommends install -y \
+ENV PATH="$PATH:$HOME/.yarn/bin"
+
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y \
         apt-transport-https \
         apt-utils \
         ca-certificates \
@@ -12,25 +14,18 @@ RUN apt-get --no-install-recommends install -y \
         gnupg \
         make \
         openssh-client \
-        software-properties-common
-
-# Install Firefox dependencies (but not Firefox)
-RUN apt-get --no-install-recommends install -y $(apt-cache depends firefox | awk '/Depends/ {print $2}')
-
-# Install node
-RUN apt-get --no-install-recommends install -y nodejs npm
-RUN apt-get --no-install-recommends install apt-transport-https
-
-# Install Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    && apt-get update \
-    && apt-get --no-install-recommends install yarn
-ENV PATH="$PATH:$HOME/.yarn/bin"
-
-# Install Firefox
-RUN yarn global add get-firefox
-RUN cd /opt && get-firefox --check --extract --verbose --branch release && ln -s /opt/firefox/firefox /usr/bin/firefox
-
-# Cleanup
-RUN apt-get clean
+        software-properties-common \
+        apt-transport-https \
+    && \
+    apt-get --no-install-recommends install -y $(apt-cache depends firefox | awk '/Depends/ {print $2}') && \
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    echo 'deb https://deb.nodesource.com/node_12.x bionic main' > /etc/apt/sources.list.d/nodesource.list && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install --no-install-recommends -y nodejs yarn && \
+    yarn global add get-firefox && \
+    cd /opt && \
+    get-firefox --check --extract --verbose --branch release && \
+    ln -s /opt/firefox/firefox /usr/bin/firefox && \
+    apt-get clean


### PR DESCRIPTION
This was blocking #102, as well as any other changes, since `get-firefox` isn't compatible with the old version we were using.