### PR TITLE
Switch to modern rust tags, for compatibility with cargo-audit

### DIFF
--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -1,10 +1,10 @@
 # latest stable Rust 1.x
-FROM rust:1-stretch@sha256:5cc6a12ecb898eb730349358ee6f679cbd3f437fdf6a608bf56d2d8e9ea444dd
+FROM rust:buster
 
 LABEL maintainer="Michael Cooper <mcooper@mozilla.com>"
 
-# cargo-kcov needs kcov >= 30. Debian Stretch has kcov 11, so these steps build
-# kcov directly.
+# cargo-kcov needs kcov >= 30, which is not in the Debian Buster repositories,
+# so build it directly using a script provided by cargo-kcov.
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get --no-install-recommends install -y apt-utils ca-certificates cmake g++ pkg-config jq libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev
@@ -13,9 +13,9 @@ RUN mkdir -p /tmp/kcov && \
     cd /tmp/kcov && \
     cargo kcov --print-install-kcov-sh | sh
 
-RUN rustup component add rustfmt && \
-    rustup component add clippy && \
-    cargo install cargo-audit
+RUN rustup component add rustfmt
+RUN rustup component add clippy
+RUN cargo install cargo-audit
 
 # Cleanup
 RUN apt-get clean && \


### PR DESCRIPTION
This should fix our failing CI jobs.