### PR TITLE
Update base images in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a collection of Docker images designed to be useful as base images in
 Circle CI tests for Mozilla projects. They are automatically kept up to date,
 and endeavor to provide a useful set of tools to run tests on.
 
-Unless otherwise noted, all images are based on Ubuntu 18.04.
+Unless otherwise noted, all images are based on Ubuntu 20.04.
 
 ## Available images
 
@@ -42,6 +42,8 @@ The latest Python 3 and Node.js 10 with
 [Therapist](https://github.com/rehandalal/therapist) pre-installed.
 A great base for linting jobs.
 
+This is based on the ``python:3.9`` image, which is built on Debian 11 (bullseye).
+
 ### Rust
 
 `mozilla/cidockerbases:rust-latest`
@@ -53,3 +55,5 @@ The latest stable version of Rust. Includes:
 - cargo-kcov for code coverage
 - sccache for faster builds (requires set up)
 - cargo-hack
+
+This is based on the ``rust:buster`` image, which is built on Debian 10 (buster).


### PR DESCRIPTION
Update the documentation for the base images:

* Docker - Ubuntu 20.04 (default)
* Firefox - Ubuntu 20.04 (default)
* Therapist - ``python:3.9``, which is built on Debian 11 (bullseye)
* Rust - ``rust:buster``, which is built on Debian 10 (buster)

For the last two, this was helpful:

```
docker run rust:buster@sha256:e6bb347e01ca274c3d4511b765f7cb9ce495d8bad3a3a99b46ae1337f7af52f6 /bin/bash -c cat /etc/*-release
docker run python:3.9@sha256:c0dcc146710fed0a6d62cb55b92f00bfbfc3b931fff6218f4958bab58333c37b /bin/bash -c cat /etc/*-release
```
