### PR TITLE
CircleCI: Update master to main, switch to cimg/base

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Deploy
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
               ./bin/push-image.sh << parameters.imageName >>
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,17 @@ jobs:
         type: string
 
     docker:
-      - image: mozilla/cidockerbases:docker-2018-08-28
+      - image: cimg/base:current-22.04
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
 
     steps:
       - checkout
 
       - setup_remote_docker:
-          version: 18.03.1-ce
+          version: 20.10.14
+          docker_layer_caching: true
 
       - run:
           name: Build


### PR DESCRIPTION
Update several aspects of the CircleCI build:

* The default branch has been renamed from `master` to `main`, so push images on merges to `main`.
* Use the the CircleCI-maintained `cimg/base:current-22.04` rather than `mozilla/cidockerbases:docker-2018-08-28`
* Update docker from `18.03.1-ce` to latest `20.10.14`, and enable layer caching
