### PR TITLE
Stop building and deploying Firefox image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,6 @@ workflows:
           imageName: docker
 
       - build-and-deploy-image:
-          name: firefox-build-and-deploy
-          imageName: firefox
-
-      - build-and-deploy-image:
           name: rust-build-and-deploy
           imageName: rust
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,6 @@ A modern version of Docker, Docker Compose, and other tools to make running
 CI easier. A version of this image is used to build all the images in this
 repository, including itself.
 
-### Firefox
-
-`mozilla/cidockerbases:firefox-latest`
-
-The latest stable version of Firefox and Node.js. A great base for running JS
-integration tests in a browser.
 
 ### Therapist
 
@@ -66,3 +60,15 @@ The latest stable version of Rust. Includes:
 - cargo-hack
 
 This is based on the ``rust:buster`` image, which is built on Debian 10 (buster).
+
+## Deprecated Images
+
+These images are no longer built or published to Dockerhub
+
+### Firefox
+
+* `mozilla/cidockerbases:firefox-latest`
+* `mozilla/cidockerbases:firefox-2022-09-02` (*final image*)
+
+The latest stable version of Firefox and Node.js. A great base for running JS
+integration tests in a browser.

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,4 @@
 status = [
-  "ci/circleci: firefox-build-and-deploy",
   "ci/circleci: docker-build-and-deploy",
   "ci/circleci: rust-build-and-deploy",
   "ci/circleci: therapist-build-and-deploy",


### PR DESCRIPTION
This image is [unused by any GitHub projects](https://github.com/search?q=filename%3Aconfig.yml+path%3A%2F.circleci+%22image%3A+mozilla%2Fcidockerbases%3Afirefox%22&type=code).